### PR TITLE
fix get_path() runtime errors

### DIFF
--- a/jupyter_server_fileid/pytest_plugin.py
+++ b/jupyter_server_fileid/pytest_plugin.py
@@ -47,9 +47,8 @@ def fs_helpers(fid_manager):
         fake_time = 1
 
         def touch(self, path, dir=False):
-            """Creates a new file at `path`. The modified time and birth time of the
-            file are guaranteed to be unique. The modified time of the parent directory
-            is guaranteed to be equal to that of the new file."""
+            """Creates a new file at `path`. The modified times of the file and
+            its parent directory are guaranteed to be unique."""
             if dir:
                 os.mkdir(path)
             else:
@@ -61,17 +60,6 @@ def fs_helpers(fid_manager):
 
             os.utime(parent, (stat.st_atime, current_time))
             os.utime(path, (current_time, current_time))
-
-            # fake new file birth time via overriding stat method
-            stat_real = fid_manager._stat
-
-            def stat_stub(input_path):
-                stat = stat_real(input_path)
-                if input_path == path:
-                    stat.crtime = current_time
-                return stat
-
-            fid_manager._stat = stat_stub
 
             self.fake_time += 1
 

--- a/jupyter_server_fileid/pytest_plugin.py
+++ b/jupyter_server_fileid/pytest_plugin.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -36,3 +37,55 @@ def fid_manager(fid_db_path, jp_root_dir):
     # also makes tests run faster :)
     fid_manager.con.execute("PRAGMA journal_mode = OFF")
     return fid_manager
+
+
+@pytest.fixture
+def fs_helpers(fid_manager):
+    class FsHelpers:
+        # seconds after test start that the `touch` and `move` methods set
+        # timestamps to
+        fake_time = 1
+
+        def touch(self, path, dir=False):
+            """Creates a new file at `path`. The modified time and birth time of the
+            file are guaranteed to be unique. The modified time of the parent directory
+            is guaranteed to be equal to that of the new file."""
+            if dir:
+                os.mkdir(path)
+            else:
+                Path(path).touch()
+
+            parent = Path(path).parent
+            stat = os.stat(path)
+            current_time = stat.st_mtime + self.fake_time
+
+            os.utime(parent, (stat.st_atime, current_time))
+            os.utime(path, (current_time, current_time))
+
+            # fake new file birth time via overriding stat method
+            stat_real = fid_manager._stat
+
+            def stat_stub(input_path):
+                stat = stat_real(input_path)
+                if input_path == path:
+                    stat.crtime = current_time
+                return stat
+
+            fid_manager._stat = stat_stub
+
+            self.fake_time += 1
+
+        def move(self, old_path, new_path):
+            """Moves a file from `old_path` to `new_path` while changing the modified
+            timestamp of the parent directory accordingly. The modified time of the
+            parent is guaranteed to be unique."""
+            os.rename(old_path, new_path)
+            parent = Path(new_path).parent
+            stat = os.stat(parent)
+            current_time = stat.st_mtime + self.fake_time
+
+            os.utime(parent, (stat.st_atime, current_time))
+
+            self.fake_time += 1
+
+    return FsHelpers()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -70,21 +70,6 @@ def get_path_nosync(fid_manager, id):
     return row and row[0]
 
 
-move_counter = 1
-
-
-def move(old_path, new_path):
-    """Moves a file from `old_path` to `new_path` while changing the modified
-    timestamp of the parent directory accordingly. The modified timestamp of the
-    parent is guaranteed to change per invocation."""
-    global move_counter
-    os.rename(old_path, new_path)
-    parent = Path(new_path).parent
-    stat = os.stat(parent)
-    os.utime(parent, (stat.st_atime, stat.st_mtime + move_counter))
-    move_counter += 1
-
-
 def test_validates_root_dir(fid_db_path):
     with pytest.raises(TraitError, match="must be an absolute path"):
         FileIdManager(root_dir=os.path.join("some", "rel", "path"), db_path=fid_db_path)
@@ -124,13 +109,11 @@ def test_index_oob_move(fid_manager, old_path, new_path):
     assert fid_manager.index(new_path) == id
 
 
-def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, jp_root_dir):
+def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, fs_helpers):
     old_id = fid_manager.index(test_path)
-    stat = os.stat(test_path)
 
     os.rmdir(test_path)
-    os.mkdir(test_path)
-    os.utime(test_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
+    fs_helpers.touch(test_path, dir=True)
     new_id = fid_manager.index(test_path)
 
     assert old_id != new_id
@@ -138,13 +121,11 @@ def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, jp_root_d
     assert fid_manager.get_path(new_id) == test_path
 
 
-def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child):
+def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child, fs_helpers):
     old_id = fid_manager.index(test_path_child)
-    stat = os.stat(test_path_child)
 
     os.remove(test_path_child)
-    Path(test_path_child).touch()
-    os.utime(test_path_child, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
+    fs_helpers.touch(test_path_child)
     new_id = fid_manager.index(test_path_child)
 
     assert old_id != new_id
@@ -279,12 +260,12 @@ def test_get_path_oob_move_into_unindexed(
     assert fid_manager.get_path(id) == new_path_child
 
 
-def test_get_path_oob_move_back_to_original_path(fid_manager, old_path, new_path):
+def test_get_path_oob_move_back_to_original_path(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
-    move(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
 
     assert fid_manager.get_path(id) == new_path
-    move(new_path, old_path)
+    fs_helpers.move(new_path, old_path)
     assert fid_manager.get_path(id) == old_path
 
 


### PR DESCRIPTION
- stops flaky runtime error with `_sync_all()` where sometimes an integrity error is returned complaining about a non-unique ino column

- fixes `get_path()` when called twice in serial
  - `test_get_path_oob_move_back_to_original_path`

- fixes `get_path()` when querying the old file ID after deleting an indexed file and creating a new indexed file at the same path
  - `test_index_after_deleting_regfile_in_same_path` and `test_index_after_deleting_dir_in_same_path`