### PR TITLE
Listen to ContentsManager save events

### DIFF
--- a/jupyter_server_fileid/extension.py
+++ b/jupyter_server_fileid/extension.py
@@ -37,7 +37,7 @@ class FileIdExtension(ExtensionApp):
         # define event handlers per contents manager action
         handlers_by_action = {
             "get": None,
-            "save": None,
+            "save": lambda data: file_id_manager.save(data["path"]),
             "rename": lambda data: file_id_manager.move(data["source_path"], data["path"]),
             "copy": lambda data: file_id_manager.copy(data["source_path"], data["path"]),
             "delete": lambda data: file_id_manager.delete(data["path"]),

--- a/jupyter_server_fileid/extension.py
+++ b/jupyter_server_fileid/extension.py
@@ -19,13 +19,20 @@ class FileIdExtension(ExtensionApp):
 
     @default("file_id_manager")
     def _file_id_manager_default(self):
-        self.log.debug("No File ID manager configured. Defaulting to FileIdManager")
+        self.log.debug("No File ID manager configured. Defaulting to FileIdManager.")
         return FileIdManager
 
     def initialize_settings(self):
         self.log.debug(f"Configured File ID manager: {self.file_id_manager_class.__name__}")
         file_id_manager = self.file_id_manager_class(log=self.log, root_dir=self.serverapp.root_dir)
         self.settings.update({"file_id_manager": file_id_manager})
+
+        # attach listener to contents manager events (requires jupyter_server~=2)
+        if "event_logger" in self.settings:
+            self.initialize_event_listeners()
+
+    def initialize_event_listeners(self):
+        file_id_manager = self.settings["file_id_manager"]
 
         # define event handlers per contents manager action
         handlers_by_action = {
@@ -36,7 +43,6 @@ class FileIdExtension(ExtensionApp):
             "delete": lambda data: file_id_manager.delete(data["path"]),
         }
 
-        # attach listener to contents manager events (JS2+)
         async def cm_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
             handler = handlers_by_action[data["action"]]
             if handler:
@@ -46,6 +52,7 @@ class FileIdExtension(ExtensionApp):
             schema_id="https://events.jupyter.org/jupyter_server/contents_service/v1",
             listener=cm_listener,
         )
+        self.log.info("Attached event listeners.")
 
     def initialize_handlers(self):
         self.handlers.extend(

--- a/jupyter_server_fileid/pytest_plugin.py
+++ b/jupyter_server_fileid/pytest_plugin.py
@@ -40,7 +40,7 @@ def fid_manager(fid_db_path, jp_root_dir):
 
 
 @pytest.fixture
-def fs_helpers(fid_manager):
+def fs_helpers():
     class FsHelpers:
         # seconds after test start that the `touch` and `move` methods set
         # timestamps to
@@ -74,6 +74,14 @@ def fs_helpers(fid_manager):
 
             os.utime(parent, (stat.st_atime, current_time))
 
+            self.fake_time += 1
+
+        def edit(self, path):
+            """Simulates editing a file at `path` by updating its modified time
+            accordingly.  The modified time of the file is guaranteed to be
+            unique."""
+            stat = os.stat(path)
+            os.utime(path, (stat.st_atime, stat.st_mtime + self.fake_time))
             self.fake_time += 1
 
     return FsHelpers()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_server>=1, <3", "jupyter_events~=0.5.0"]
+dependencies = ["jupyter_server>=1.15, <3", "jupyter_events~=0.5.0"]
 
 [project.optional-dependencies]
 test = [
   "pytest",
   "pytest-cov",
-  "jupyter_server[test]>=1, <3"
+  "jupyter_server[test]>=1.15, <3"
 ]
 
 cli = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_server~=2.0.0rc1", "jupyter_events~=0.5.0"]
+dependencies = ["jupyter_server<=2.0.0rc1,>=1", "jupyter_events~=0.5.0"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_server<=2.0.0rc1,>=1", "jupyter_events~=0.5.0"]
+dependencies = ["jupyter_server>=1, <3", "jupyter_events~=0.5.0"]
 
 [project.optional-dependencies]
 test = [
   "pytest",
   "pytest-cov",
-  "jupyter_server[test]~=2.0.0rc1"
+  "jupyter_server[test]>=1, <3"
 ]
 
 cli = [

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -420,3 +420,12 @@ def test_delete_recursive(fid_manager, test_path, test_path_child):
     fid_manager.delete(test_path)
 
     assert fid_manager.get_id(test_path_child) is None
+
+
+def test_save(fid_manager, test_path, fs_helpers):
+    id = fid_manager.index(test_path)
+
+    fs_helpers.edit(test_path)
+    fid_manager.save(test_path)
+
+    assert fid_manager.get_id(test_path) == id


### PR DESCRIPTION
- Allow for JS1 to be used alongside File ID extension
- Listen to ContentsManager save events and update stat info in the Files table accordingly (see #15)