### PR TITLE
update get_path() to return a path relative to root_dir

### DIFF
--- a/jupyter_server_fileid/manager.py
+++ b/jupyter_server_fileid/manager.py
@@ -408,9 +408,10 @@ class FileIdManager(LoggingConfigurable):
         return id
 
     def get_path(self, id, sync=True):
-        """Retrieves the file path associated with a file ID. Returns None if
-        the ID does not exist in the Files table or if the corresponding path no
-        longer has a file.
+        """Retrieves the file path associated with a file ID. The file path is
+        relative to `self.root_dir`. Returns None if the ID does not
+        exist in the Files table, if the path no longer has a
+        file, or if the path is not a child of `self.root_dir`.
 
         Parameters
         ----------
@@ -443,6 +444,12 @@ class FileIdManager(LoggingConfigurable):
         if ino != stat_info.ino or not self._check_timestamps(stat_info):
             return None
 
+        # if path is not relative to `self.root_dir`, return None.
+        if os.path.commonpath([self.root_dir, path]) != self.root_dir:
+            return None
+
+        # finally, convert the path to a relative one.
+        path = os.path.relpath(path, self.root_dir)
         return path
 
     def _move_recursive(self, old_path, new_path):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-from pathlib import Path
 
 import pytest
 from traitlets import TraitError
@@ -9,45 +7,45 @@ from jupyter_server_fileid.manager import FileIdManager
 
 
 @pytest.fixture
-def test_path(jp_root_dir):
-    path = os.path.join(jp_root_dir, "test_path")
-    os.mkdir(path)
+def test_path(fs_helpers):
+    path = "test_path"
+    fs_helpers.touch(path, dir=True)
     return path
 
 
 @pytest.fixture
-def test_path_child(test_path):
+def test_path_child(test_path, fs_helpers):
     path = os.path.join(test_path, "child")
-    Path(path).touch()
+    fs_helpers.touch(path)
     return path
 
 
 @pytest.fixture
-def old_path(jp_root_dir):
+def old_path(fs_helpers):
     """Fixture for source path to be moved/copied via FID manager"""
-    path = os.path.join(jp_root_dir, "old_path")
-    os.mkdir(path)
+    path = "old_path"
+    fs_helpers.touch(path, dir=True)
     return path
 
 
 @pytest.fixture
-def old_path_child(old_path):
+def old_path_child(old_path, fs_helpers):
     path = os.path.join(old_path, "child")
-    os.mkdir(path)
+    fs_helpers.touch(path, dir=True)
     return path
 
 
 @pytest.fixture
-def old_path_grandchild(old_path_child):
+def old_path_grandchild(old_path_child, fs_helpers):
     path = os.path.join(old_path_child, "grandchild")
-    os.mkdir(path)
+    fs_helpers.touch(path)
     return path
 
 
 @pytest.fixture
-def new_path(jp_root_dir):
+def new_path():
     """Fixture for destination path for a FID manager move/copy operation"""
-    return os.path.join(jp_root_dir, "new_path")
+    return "new_path"
 
 
 @pytest.fixture
@@ -61,13 +59,21 @@ def new_path_grandchild(new_path_child):
 
 
 def get_id_nosync(fid_manager, path):
+    if not os.path.isabs(path):
+        path = os.path.join(fid_manager.root_dir, path)
+
     row = fid_manager.con.execute("SELECT id FROM Files WHERE path = ?", (path,)).fetchone()
     return row and row[0]
 
 
 def get_path_nosync(fid_manager, id):
     row = fid_manager.con.execute("SELECT path FROM Files WHERE id = ?", (id,)).fetchone()
-    return row and row[0]
+    path = row and row[0]
+
+    if path is None:
+        return None
+
+    return os.path.relpath(path, fid_manager.root_dir)
 
 
 def test_validates_root_dir(fid_db_path):
@@ -90,9 +96,9 @@ def test_index_already_indexed(fid_manager, test_path):
     assert id == fid_manager.index(test_path)
 
 
-def test_index_symlink(fid_manager, test_path, jp_root_dir):
-    link_path = os.path.join(jp_root_dir, "link_path")
-    os.symlink(test_path, link_path)
+def test_index_symlink(fid_manager, test_path):
+    link_path = os.path.join(fid_manager.root_dir, "link_path")
+    os.symlink(os.path.join(fid_manager.root_dir, test_path), link_path)
     id = fid_manager.index(link_path)
 
     # we want to assert that the "real path" is the only path associated with an
@@ -103,16 +109,16 @@ def test_index_symlink(fid_manager, test_path, jp_root_dir):
 
 
 # test out-of-band move detection for FIM.index()
-def test_index_oob_move(fid_manager, old_path, new_path):
+def test_index_oob_move(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
     assert fid_manager.index(new_path) == id
 
 
 def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, fs_helpers):
     old_id = fid_manager.index(test_path)
 
-    os.rmdir(test_path)
+    fs_helpers.delete(test_path)
     fs_helpers.touch(test_path, dir=True)
     new_id = fid_manager.index(test_path)
 
@@ -124,7 +130,7 @@ def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, fs_helper
 def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child, fs_helpers):
     old_id = fid_manager.index(test_path_child)
 
-    os.remove(test_path_child)
+    fs_helpers.delete(test_path_child)
     fs_helpers.touch(test_path_child)
     new_id = fid_manager.index(test_path_child)
 
@@ -155,9 +161,10 @@ def stub_stat_crtime(fid_manager, request):
 # sync file should work even after directory mtime changes when children are
 # added/removed/renamed on platforms supporting crtime
 def test_index_crtime(fid_manager, test_path, stub_stat_crtime):
-    stat = os.stat(test_path)
+    abs_path = os.path.join(fid_manager.root_dir, test_path)
+    stat = os.stat(abs_path)
     id = fid_manager.index(test_path)
-    os.utime(test_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
+    os.utime(abs_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
 
     assert fid_manager.index(test_path) == id
 
@@ -169,11 +176,11 @@ def test_getters_indexed(fid_manager, test_path):
     assert fid_manager.get_path(id) == test_path
 
 
-def test_getters_nonnormalized(fid_manager, test_path):
+def test_getters_nonnormalized(fid_manager, test_path, fs_helpers):
     path1 = os.path.join(test_path, "file")
     path2 = os.path.join(test_path, "some_dir", "..", "file")
     path3 = os.path.join(test_path, ".", ".", ".", "file")
-    Path(path1).touch()
+    fs_helpers.touch(path1)
 
     id = fid_manager.index(path1)
 
@@ -182,9 +189,9 @@ def test_getters_nonnormalized(fid_manager, test_path):
     assert fid_manager.get_id(path3) == id
 
 
-def test_getters_oob_delete(fid_manager, test_path):
+def test_getters_oob_delete(fid_manager, test_path, fs_helpers):
     id = fid_manager.index(test_path)
-    os.rmdir(test_path)
+    fs_helpers.delete(test_path)
     assert id is not None
     assert fid_manager.get_id(test_path) is None
     assert fid_manager.get_path(id) is None
@@ -195,17 +202,19 @@ def test_get_id_unindexed(fid_manager, test_path_child):
 
 
 # test out-of-band move detection for FIM.get_id()
-def test_get_id_oob_move(fid_manager, old_path, new_path):
+def test_get_id_oob_move(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
     assert fid_manager.get_id(new_path) == id
 
 
-def test_get_id_oob_move_recursive(fid_manager, old_path, old_path_child, new_path, new_path_child):
+def test_get_id_oob_move_recursive(
+    fid_manager, old_path, old_path_child, new_path, new_path_child, fs_helpers
+):
     parent_id = fid_manager.index(old_path)
     child_id = fid_manager.index(old_path_child)
 
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
 
     assert fid_manager.get_id(new_path) == parent_id
     assert fid_manager.get_id(new_path_child) == child_id
@@ -215,14 +224,14 @@ def test_get_id_oob_move_recursive(fid_manager, old_path, old_path_child, new_pa
 # at the old path.  this is what forces relaxation of the UNIQUE constraint on
 # path column, since we need to keep records of deleted files that used to
 # occupy a path, which is possibly occupied by a new file.
-def test_get_id_oob_move_new_file_at_old_path(fid_manager, old_path, new_path, jp_root_dir):
+def test_get_id_oob_move_new_file_at_old_path(fid_manager, old_path, new_path, fs_helpers):
     old_id = fid_manager.index(old_path)
-    other_path = os.path.join(jp_root_dir, "other_path")
+    other_path = "other_path"
 
-    os.rename(old_path, new_path)
-    Path(old_path).touch()
+    fs_helpers.move(old_path, new_path)
+    fs_helpers.touch(old_path)
     other_id = fid_manager.index(old_path)
-    os.rename(old_path, other_path)
+    fs_helpers.move(old_path, other_path)
 
     assert other_id != old_id
     assert fid_manager.get_id(new_path) == old_id
@@ -230,32 +239,32 @@ def test_get_id_oob_move_new_file_at_old_path(fid_manager, old_path, new_path, j
     assert fid_manager.get_id(other_path) == other_id
 
 
-def test_get_path_oob_move(fid_manager, old_path, new_path):
+def test_get_path_oob_move(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
     assert fid_manager.get_path(id) == new_path
 
 
 def test_get_path_oob_move_recursive(
-    fid_manager, old_path, old_path_child, new_path, new_path_child
+    fid_manager, old_path, old_path_child, new_path, new_path_child, fs_helpers
 ):
     id = fid_manager.index(old_path)
     child_id = fid_manager.index(old_path_child)
 
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
 
     assert fid_manager.get_path(id) == new_path
     assert fid_manager.get_path(child_id) == new_path_child
 
 
 def test_get_path_oob_move_into_unindexed(
-    fid_manager, old_path, old_path_child, new_path, new_path_child
+    fid_manager, old_path, old_path_child, new_path, new_path_child, fs_helpers
 ):
     fid_manager.index(old_path)
     id = fid_manager.index(old_path_child)
 
-    os.mkdir(new_path)
-    os.rename(old_path_child, new_path_child)
+    fs_helpers.touch(new_path, dir=True)
+    fs_helpers.move(old_path_child, new_path_child)
 
     assert fid_manager.get_path(id) == new_path_child
 
@@ -272,21 +281,15 @@ def test_get_path_oob_move_back_to_original_path(fid_manager, old_path, new_path
 # move file into an indexed-but-moved directory
 # this test should work regardless of whether crtime is supported on platform
 @pytest.mark.parametrize("stub_stat_crtime", [True, False], indirect=["stub_stat_crtime"])
-def test_get_path_oob_move_nested(fid_manager, old_path, new_path, jp_root_dir, stub_stat_crtime):
-    old_test_path = os.path.join(jp_root_dir, "test_path")
+def test_get_path_oob_move_nested(fid_manager, old_path, new_path, stub_stat_crtime, fs_helpers):
+    old_test_path = "test_path"
     new_test_path = os.path.join(new_path, "test_path")
-    Path(old_test_path).touch()
-    stat = os.stat(old_test_path)
+    fs_helpers.touch(old_test_path)
     fid_manager.index(old_path)
     id = fid_manager.index(old_test_path)
 
-    os.rename(old_path, new_path)
-    os.rename(old_test_path, new_test_path)
-    # ensure new_path has different mtime after moving test_path. moving a file
-    # into an indexed-but-moved dir has a chance of not changing the dir's
-    # mtime. since we fallback to mtime, this makes the dir look unindexed and
-    # causes this test to flakily pass when it should not.
-    os.utime(new_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
+    fs_helpers.move(old_path, new_path)
+    fs_helpers.move(old_test_path, new_test_path)
 
     assert fid_manager.get_path(id) == new_test_path
 
@@ -295,25 +298,23 @@ def test_get_path_oob_move_nested(fid_manager, old_path, new_path, jp_root_dir, 
 # this test should work regardless of whether crtime is supported on platform
 @pytest.mark.parametrize("stub_stat_crtime", [True, False], indirect=["stub_stat_crtime"])
 def test_get_path_oob_move_deeply_nested(
-    fid_manager, old_path, new_path, old_path_child, new_path_child, jp_root_dir, stub_stat_crtime
+    fid_manager, old_path, new_path, old_path_child, new_path_child, stub_stat_crtime, fs_helpers
 ):
-    old_test_path = os.path.join(jp_root_dir, "test_path")
+    old_test_path = "test_path"
     new_test_path = os.path.join(new_path_child, "test_path")
-    Path(old_test_path).touch()
-    stat = os.stat(old_test_path)
+    fs_helpers.touch(old_test_path)
     fid_manager.index(old_path)
     fid_manager.index(old_path_child)
     id = fid_manager.index(old_test_path)
 
-    os.rename(old_path, new_path)
-    os.rename(old_test_path, new_test_path)
-    os.utime(new_path_child, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
+    fs_helpers.move(old_path, new_path)
+    fs_helpers.move(old_test_path, new_test_path)
 
     assert fid_manager.get_path(id) == new_test_path
 
 
-def test_move_unindexed(fid_manager, old_path, new_path):
-    os.rename(old_path, new_path)
+def test_move_unindexed(fid_manager, old_path, new_path, fs_helpers):
+    fs_helpers.move(old_path, new_path)
     id = fid_manager.move(old_path, new_path)
 
     assert id is not None
@@ -322,10 +323,10 @@ def test_move_unindexed(fid_manager, old_path, new_path):
     assert fid_manager.get_path(id) == new_path
 
 
-def test_move_indexed(fid_manager, old_path, new_path):
+def test_move_indexed(fid_manager, old_path, new_path, fs_helpers):
     old_id = fid_manager.index(old_path)
 
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
     new_id = fid_manager.move(old_path, new_path)
 
     assert old_id == new_id
@@ -336,11 +337,11 @@ def test_move_indexed(fid_manager, old_path, new_path):
 
 # test for disjoint move handling
 # disjoint move: any out-of-band move that does not preserve stat info
-def test_disjoint_move_indexed(fid_manager, old_path, new_path):
+def test_disjoint_move_indexed(fid_manager, old_path, new_path, fs_helpers):
     old_id = fid_manager.index(old_path)
 
-    os.rmdir(old_path)
-    os.mkdir(new_path)
+    fs_helpers.delete(old_path)
+    fs_helpers.touch(new_path, dir=True)
     new_id = fid_manager.move(old_path, new_path)
 
     assert old_id == new_id
@@ -354,12 +355,13 @@ def test_move_recursive(
     new_path,
     new_path_child,
     new_path_grandchild,
+    fs_helpers,
 ):
     parent_id = fid_manager.index(old_path)
     child_id = fid_manager.index(old_path_child)
     grandchild_id = fid_manager.index(old_path_grandchild)
 
-    os.rename(old_path, new_path)
+    fs_helpers.move(old_path, new_path)
     fid_manager.move(old_path, new_path)
 
     # we avoid using get_id() here as it auto-corrects wrong path updates via
@@ -369,10 +371,8 @@ def test_move_recursive(
     assert get_id_nosync(fid_manager, new_path_grandchild) == grandchild_id
 
 
-def test_copy(fid_manager, old_path, new_path):
-    shutil.copytree(old_path, new_path)
-    print(os.path.exists(new_path))
-    print(fid_manager.index(new_path))
+def test_copy(fid_manager, old_path, new_path, fs_helpers):
+    fs_helpers.copy(old_path, new_path)
     new_id = fid_manager.copy(old_path, new_path)
     old_id = fid_manager.get_id(old_path)
 
@@ -389,12 +389,13 @@ def test_copy_recursive(
     new_path,
     new_path_child,
     new_path_grandchild,
+    fs_helpers,
 ):
     fid_manager.index(old_path)
     fid_manager.index(old_path_child)
     fid_manager.index(old_path_grandchild)
 
-    shutil.copytree(old_path, new_path)
+    fs_helpers.copy(old_path, new_path)
     fid_manager.copy(old_path, new_path)
 
     assert fid_manager.get_id(new_path) is not None
@@ -402,21 +403,21 @@ def test_copy_recursive(
     assert fid_manager.get_id(new_path_grandchild) is not None
 
 
-def test_delete(fid_manager, test_path):
+def test_delete(fid_manager, test_path, fs_helpers):
     id = fid_manager.index(test_path)
 
-    shutil.rmtree(test_path)
+    fs_helpers.delete(test_path)
     fid_manager.delete(test_path)
 
     assert fid_manager.get_id(test_path) is None
     assert fid_manager.get_path(id) is None
 
 
-def test_delete_recursive(fid_manager, test_path, test_path_child):
+def test_delete_recursive(fid_manager, test_path, test_path_child, fs_helpers):
     fid_manager.index(test_path)
     fid_manager.index(test_path_child)
 
-    shutil.rmtree(test_path)
+    fs_helpers.delete(test_path)
     fid_manager.delete(test_path)
 
     assert fid_manager.get_id(test_path_child) is None


### PR DESCRIPTION
`get_path()` now returns a path relative to its configured `root_dir` trait, which should be set to the server root. Developers using `jupyter_server_fileid` (e.g. scheduling, RTC) have found that relative paths are being used far more in the Jupyter ecosystem than absolute ones, and thus `get_path()` should default to returning a relative path instead.

To revert back to the old behavior, this can be done manually via:

```
path = file_id_manager.get_path(id)
os.path.join(file_id_manager.root_dir, path) 
```

If there is a demonstrated use-case for absolute paths, I'd be happy to add an argument `absolute: bool` to `get_path()` that allows for users to be returned an absolute path. However, at the present moment, there are no known usecases for it.