### PR TITLE
Make ArbitraryFileIdManager filesystem-agnostic and fix Windows CI

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,7 +1,7 @@
 name: Tests
 on:
   push:
-  #  branches: ["main"]
+    branches: ["main"]
   pull_request:
   schedule:
     - cron: "0 8 * * *"
@@ -25,8 +25,8 @@ jobs:
         include:
           - os: windows-latest
             python-version: "3.9"
-          - os: ubuntu-latest
-            python-version: "pypy-3.8"
+          # - os: ubuntu-latest
+          #   python-version: "pypy-3.8"
           - os: macos-latest
             python-version: "3.8"
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,7 +1,7 @@
 name: Tests
 on:
   push:
-    branches: ["main"]
+  #  branches: ["main"]
   pull_request:
   schedule:
     - cron: "0 8 * * *"
@@ -19,14 +19,14 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # - windows-latest
+          - windows-latest
           - macos-latest
         python-version: ["3.7", "3.10"]
         include:
-          # - os: windows-latest
-          #   python-version: "3.9"
-          # - os: ubuntu-latest
-          #   python-version: "pypy-3.8"
+          - os: windows-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "pypy-3.8"
           - os: macos-latest
             python-version: "3.8"
     steps:

--- a/jupyter_server_fileid/manager.py
+++ b/jupyter_server_fileid/manager.py
@@ -220,6 +220,15 @@ class ArbitraryFileIdManager(BaseFileIdManager):
     Server 2.
     """
 
+    @validate("root_dir")
+    def _validate_root_dir(self, proposal):
+        # Convert root_dir to an api path, since that's essentially what we persist.
+        if proposal["value"] is None:
+            return ""
+
+        normalized_content_root = self._normalize_separators(proposal["value"])
+        return normalized_content_root
+
     def __init__(self, *args, **kwargs):
         # pass args and kwargs to parent Configurable
         super().__init__(*args, **kwargs)
@@ -255,10 +264,10 @@ class ArbitraryFileIdManager(BaseFileIdManager):
         # use commonprefix instead of commonpath, since root_dir may not be a
         # absolute POSIX path.
 
-        norm_root_dir = self._normalize_separators(self.root_dir)
+        # norm_root_dir = self._normalize_separators(self.root_dir)
         path = self._normalize_separators(path)
-        if posixpath.commonprefix([norm_root_dir, path]) != norm_root_dir:
-            path = posixpath.join(norm_root_dir, path)
+        if posixpath.commonprefix([self.root_dir, path]) != self.root_dir:
+            path = posixpath.join(self.root_dir, path)
 
         return path
 
@@ -270,11 +279,11 @@ class ArbitraryFileIdManager(BaseFileIdManager):
             return None
 
         # Convert root_dir to an api path, since that's essentially what we persist.
-        norm_root_dir = self._normalize_separators(self.root_dir)
-        if posixpath.commonprefix([norm_root_dir, path]) != norm_root_dir:
+        # norm_root_dir = self._normalize_separators(self.root_dir)
+        if posixpath.commonprefix([self.root_dir, path]) != self.root_dir:
             return None
 
-        relpath = posixpath.relpath(path, norm_root_dir)
+        relpath = posixpath.relpath(path, self.root_dir)
         return relpath
 
     def _create(self, path: str) -> str:

--- a/jupyter_server_fileid/manager.py
+++ b/jupyter_server_fileid/manager.py
@@ -741,7 +741,9 @@ class LocalFileIdManager(BaseFileIdManager):
         """
         # optimistic approach: first check to see if path was not yet moved
         for retry in [True, False]:
-            row = self.con.execute("SELECT path, ino, crtime, mtime FROM Files WHERE id = ?", (id,)).fetchone()
+            row = self.con.execute(
+                "SELECT path, ino, crtime, mtime FROM Files WHERE id = ?", (id,)
+            ).fetchone()
 
             # if file ID does not exist, return None
             if not row:
@@ -750,7 +752,11 @@ class LocalFileIdManager(BaseFileIdManager):
             path, ino, crtime, mtime = row
             stat_info = self._stat(path)
 
-            if stat_info and ino == stat_info.ino and self._check_timestamps(stat_info, crtime, mtime):
+            if (
+                stat_info
+                and ino == stat_info.ino
+                and self._check_timestamps(stat_info, crtime, mtime)
+            ):
                 # if file already exists at path and the ino and timestamps match,
                 # then return the correct path immediately (best case)
                 return self._from_normalized_path(path)

--- a/jupyter_server_fileid/manager.py
+++ b/jupyter_server_fileid/manager.py
@@ -434,16 +434,18 @@ class LocalFileIdManager(BaseFileIdManager):
         return path
 
     def _from_normalized_path(self, path: Optional[str]) -> Optional[str]:
-        """Accepts a filesystem path and returns an API path, i.e. one relative
-        to root_dir and uses forward slashes as the path separator. Returns
-        `None` if the given path is None or is not relative to root_dir."""
+        """Accepts a "persisted" filesystem path and returns an API path, i.e.
+        one relative to root_dir and uses forward slashes as the path separator.
+        Returns `None` if the given path is None or is not relative to root_dir.
+        """
         if path is None:
             return None
 
-        if os.path.commonprefix([self.root_dir, path]) != self.root_dir:
+        norm_root_dir = os.path.normcase(self.root_dir)
+        if os.path.commonprefix([norm_root_dir, path]) != norm_root_dir:
             return None
 
-        relpath = os.path.relpath(path, self.root_dir)
+        relpath = os.path.relpath(path, norm_root_dir)
         # always use forward slashes to delimit children
         relpath = relpath.replace(os.path.sep, "/")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,6 +1,7 @@
 import ntpath
 import os
 import posixpath
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -186,6 +187,10 @@ def test_index_already_indexed(any_fid_manager, test_path):
     assert id == any_fid_manager.index(test_path)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8) and sys.platform.startswith("win"),
+    reason="symbolic links on Windows Python 3.7 not behaving like 3.8+",
+)
 def test_index_symlink(fid_manager, test_path):
     link_path = os.path.join(fid_manager.root_dir, "link_path")
     os.symlink(os.path.join(fid_manager.root_dir, test_path), link_path)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -94,7 +94,7 @@ def normalize_path(fid_manager: BaseFileIdManager, path: str) -> str:
     manager must be filesystem agnostic.
     """
     if isinstance(fid_manager, LocalFileIdManager):
-        return os.path.normcase(path)
+        path = os.path.normcase(path)
     
     parts = path.strip("\\").split("\\")
     return "/".join(parts)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from traitlets import TraitError
 
-from jupyter_server_fileid.manager import ArbitraryFileIdManager, LocalFileIdManager
+from jupyter_server_fileid.manager import ArbitraryFileIdManager, BaseFileIdManager, LocalFileIdManager
 
 
 @pytest.fixture
@@ -78,6 +78,17 @@ def get_path_nosync(fid_manager, id):
     return os.path.relpath(path, fid_manager.root_dir)
 
 
+def normalize_case(fid_manager: BaseFileIdManager, path: str) -> str:
+    """Normalize case based on operating system and FileIdManager instance.
+
+    When testing instances of LocalFileIdManager, we need to normalize the
+    case relative to the OS when comparing results of get_path(), otherwise not.
+    """
+    if isinstance(fid_manager, LocalFileIdManager):
+        return os.path.normcase(path)
+    return path
+
+
 def test_validates_root_dir(fid_db_path):
     root_dir = "s3://bucket"
     with pytest.raises(TraitError, match="must be an absolute path"):
@@ -143,7 +154,7 @@ def test_index_symlink(fid_manager, test_path):
     # ID. get_path() *sometimes* returns the real path if _sync_file() happens
     # to be called on the real path after the symlink path when _sync_all() is
     # run, causing this test to flakily pass when it shouldn't.
-    assert get_path_nosync(fid_manager, id) == test_path
+    assert get_path_nosync(fid_manager, id) == normalize_case(fid_manager, test_path)
 
 
 # test out-of-band move detection for FIM.index()
@@ -162,7 +173,7 @@ def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, fs_helper
 
     assert old_id != new_id
     assert fid_manager.get_path(old_id) is None
-    assert fid_manager.get_path(new_id) == test_path
+    assert fid_manager.get_path(new_id) == normalize_case(fid_manager, test_path)
 
 
 def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child, fs_helpers):
@@ -174,7 +185,7 @@ def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child,
 
     assert old_id != new_id
     assert fid_manager.get_path(old_id) is None
-    assert fid_manager.get_path(new_id) == test_path_child
+    assert fid_manager.get_path(new_id) == normalize_case(fid_manager, test_path_child)
 
 
 @pytest.fixture
@@ -211,7 +222,7 @@ def test_getters_indexed(any_fid_manager, test_path):
     id = any_fid_manager.index(test_path)
 
     assert any_fid_manager.get_id(test_path) == id
-    assert any_fid_manager.get_path(id) == test_path
+    assert any_fid_manager.get_path(id) == normalize_case(any_fid_manager, test_path)
 
 
 def test_getters_nonnormalized(fid_manager, test_path, fs_helpers):
@@ -273,7 +284,7 @@ def test_get_id_oob_move_new_file_at_old_path(fid_manager, old_path, new_path, f
 
     assert other_id != old_id
     assert fid_manager.get_id(new_path) == old_id
-    assert fid_manager.get_path(old_id) == new_path
+    assert fid_manager.get_path(old_id) == normalize_case(fid_manager, new_path)
     assert fid_manager.get_id(other_path) == other_id
 
 
@@ -282,7 +293,7 @@ def test_get_path_arbitrary_preserves_path(arbitrary_fid_manager):
     receives."""
     path = "AbCd.txt"
     id = arbitrary_fid_manager.index(path)
-    assert path == arbitrary_fid_manager.get_path(id)
+    assert normalize_case(arbitrary_fid_manager, path) == arbitrary_fid_manager.get_path(id)
 
 
 @patch("os.path.sep", new="\\")
@@ -301,7 +312,7 @@ def test_get_path_returns_api_path(jp_root_dir, fid_db_path):
 
     id = manager.index(test_path)
     path = manager.get_path(id)
-    assert path == expected_path
+    assert path == normalize_case(manager, expected_path)
 
 
 def test_optimistic_get_path(fid_manager, test_path, test_path_child):
@@ -320,7 +331,7 @@ def test_optimistic_get_path(fid_manager, test_path, test_path_child):
 def test_get_path_oob_move(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
     fs_helpers.move(old_path, new_path)
-    assert fid_manager.get_path(id) == new_path
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path)
 
 
 def test_get_path_oob_move_recursive(
@@ -331,8 +342,8 @@ def test_get_path_oob_move_recursive(
 
     fs_helpers.move(old_path, new_path)
 
-    assert fid_manager.get_path(id) == new_path
-    assert fid_manager.get_path(child_id) == new_path_child
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path)
+    assert fid_manager.get_path(child_id) == normalize_case(fid_manager, new_path_child)
 
 
 def test_get_path_oob_move_into_unindexed(
@@ -344,16 +355,16 @@ def test_get_path_oob_move_into_unindexed(
     fs_helpers.touch(new_path, dir=True)
     fs_helpers.move(old_path_child, new_path_child)
 
-    assert fid_manager.get_path(id) == new_path_child
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path_child)
 
 
 def test_get_path_oob_move_back_to_original_path(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
     fs_helpers.move(old_path, new_path)
 
-    assert fid_manager.get_path(id) == new_path
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path)
     fs_helpers.move(new_path, old_path)
-    assert fid_manager.get_path(id) == old_path
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, old_path)
 
 
 # move file into an indexed-but-moved directory
@@ -369,7 +380,7 @@ def test_get_path_oob_move_nested(fid_manager, old_path, new_path, stub_stat_crt
     fs_helpers.move(old_path, new_path)
     fs_helpers.move(old_test_path, new_test_path)
 
-    assert fid_manager.get_path(id) == new_test_path
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_test_path)
 
 
 # move file into directory within an indexed-but-moved directory
@@ -388,7 +399,7 @@ def test_get_path_oob_move_deeply_nested(
     fs_helpers.move(old_path, new_path)
     fs_helpers.move(old_test_path, new_test_path)
 
-    assert fid_manager.get_path(id) == new_test_path
+    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_test_path)
 
 
 def test_move_unindexed(any_fid_manager, old_path, new_path, fs_helpers):
@@ -398,7 +409,7 @@ def test_move_unindexed(any_fid_manager, old_path, new_path, fs_helpers):
     assert id is not None
     assert any_fid_manager.get_id(old_path) is None
     assert any_fid_manager.get_id(new_path) == id
-    assert any_fid_manager.get_path(id) == new_path
+    assert any_fid_manager.get_path(id) == normalize_case(any_fid_manager, new_path)
 
 
 def test_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):
@@ -410,7 +421,7 @@ def test_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):
     assert old_id == new_id
     assert any_fid_manager.get_id(old_path) is None
     assert any_fid_manager.get_id(new_path) == new_id
-    assert any_fid_manager.get_path(old_id) == new_path
+    assert any_fid_manager.get_path(old_id) == normalize_case(any_fid_manager, new_path)
 
 
 # test for disjoint move handling

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 import pytest
 from traitlets import TraitError
 
-from jupyter_server_fileid.manager import ArbitraryFileIdManager, BaseFileIdManager, LocalFileIdManager
+from jupyter_server_fileid.manager import (
+    ArbitraryFileIdManager,
+    BaseFileIdManager,
+    LocalFileIdManager,
+)
 
 
 @pytest.fixture
@@ -78,15 +82,22 @@ def get_path_nosync(fid_manager, id):
     return os.path.relpath(path, fid_manager.root_dir)
 
 
-def normalize_case(fid_manager: BaseFileIdManager, path: str) -> str:
-    """Normalize case based on operating system and FileIdManager instance.
+def normalize_path(fid_manager: BaseFileIdManager, path: str) -> str:
+    """Normalize path or case based on operating system and FileIdManager instance.
 
     When testing instances of LocalFileIdManager, we need to normalize the
-    case relative to the OS when comparing results of get_path(), otherwise not.
+    case relative to the OS when comparing results of get_path() since Windows
+    is case-insensitive.
+
+    When testing instances of ArbitraryFileIdManager, we need to normalize the
+    path, regardless of OS, when comparing results of get_path() since this fileID
+    manager must be filesystem agnostic.
     """
     if isinstance(fid_manager, LocalFileIdManager):
         return os.path.normcase(path)
-    return path
+    
+    parts = path.strip("\\").split("\\")
+    return "/".join(parts)
 
 
 def test_validates_root_dir(fid_db_path):
@@ -154,7 +165,7 @@ def test_index_symlink(fid_manager, test_path):
     # ID. get_path() *sometimes* returns the real path if _sync_file() happens
     # to be called on the real path after the symlink path when _sync_all() is
     # run, causing this test to flakily pass when it shouldn't.
-    assert get_path_nosync(fid_manager, id) == normalize_case(fid_manager, test_path)
+    assert get_path_nosync(fid_manager, id) == normalize_path(fid_manager, test_path)
 
 
 # test out-of-band move detection for FIM.index()
@@ -173,7 +184,7 @@ def test_index_after_deleting_dir_in_same_path(fid_manager, test_path, fs_helper
 
     assert old_id != new_id
     assert fid_manager.get_path(old_id) is None
-    assert fid_manager.get_path(new_id) == normalize_case(fid_manager, test_path)
+    assert fid_manager.get_path(new_id) == normalize_path(fid_manager, test_path)
 
 
 def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child, fs_helpers):
@@ -185,7 +196,7 @@ def test_index_after_deleting_regfile_in_same_path(fid_manager, test_path_child,
 
     assert old_id != new_id
     assert fid_manager.get_path(old_id) is None
-    assert fid_manager.get_path(new_id) == normalize_case(fid_manager, test_path_child)
+    assert fid_manager.get_path(new_id) == normalize_path(fid_manager, test_path_child)
 
 
 @pytest.fixture
@@ -222,7 +233,7 @@ def test_getters_indexed(any_fid_manager, test_path):
     id = any_fid_manager.index(test_path)
 
     assert any_fid_manager.get_id(test_path) == id
-    assert any_fid_manager.get_path(id) == normalize_case(any_fid_manager, test_path)
+    assert any_fid_manager.get_path(id) == normalize_path(any_fid_manager, test_path)
 
 
 def test_getters_nonnormalized(fid_manager, test_path, fs_helpers):
@@ -284,7 +295,7 @@ def test_get_id_oob_move_new_file_at_old_path(fid_manager, old_path, new_path, f
 
     assert other_id != old_id
     assert fid_manager.get_id(new_path) == old_id
-    assert fid_manager.get_path(old_id) == normalize_case(fid_manager, new_path)
+    assert fid_manager.get_path(old_id) == normalize_path(fid_manager, new_path)
     assert fid_manager.get_id(other_path) == other_id
 
 
@@ -293,13 +304,9 @@ def test_get_path_arbitrary_preserves_path(arbitrary_fid_manager):
     receives."""
     path = "AbCd.txt"
     id = arbitrary_fid_manager.index(path)
-    assert normalize_case(arbitrary_fid_manager, path) == arbitrary_fid_manager.get_path(id)
+    assert normalize_path(arbitrary_fid_manager, path) == arbitrary_fid_manager.get_path(id)
 
 
-@patch("os.path.sep", new="\\")
-@patch("os.path.relpath", new=ntpath.relpath)
-@patch("os.path.normpath", new=ntpath.normpath)
-@patch("os.path.join", new=ntpath.join)
 def test_get_path_returns_api_path(jp_root_dir, fid_db_path):
     """Tests whether get_path() method always returns an API path, i.e. one
     relative to the server root and one delimited by forward slashes (even if
@@ -312,7 +319,7 @@ def test_get_path_returns_api_path(jp_root_dir, fid_db_path):
 
     id = manager.index(test_path)
     path = manager.get_path(id)
-    assert path == normalize_case(manager, expected_path)
+    assert path == normalize_path(manager, expected_path)
 
 
 def test_optimistic_get_path(fid_manager, test_path, test_path_child):
@@ -331,7 +338,7 @@ def test_optimistic_get_path(fid_manager, test_path, test_path_child):
 def test_get_path_oob_move(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
     fs_helpers.move(old_path, new_path)
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, new_path)
 
 
 def test_get_path_oob_move_recursive(
@@ -342,8 +349,8 @@ def test_get_path_oob_move_recursive(
 
     fs_helpers.move(old_path, new_path)
 
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path)
-    assert fid_manager.get_path(child_id) == normalize_case(fid_manager, new_path_child)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, new_path)
+    assert fid_manager.get_path(child_id) == normalize_path(fid_manager, new_path_child)
 
 
 def test_get_path_oob_move_into_unindexed(
@@ -355,16 +362,16 @@ def test_get_path_oob_move_into_unindexed(
     fs_helpers.touch(new_path, dir=True)
     fs_helpers.move(old_path_child, new_path_child)
 
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path_child)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, new_path_child)
 
 
 def test_get_path_oob_move_back_to_original_path(fid_manager, old_path, new_path, fs_helpers):
     id = fid_manager.index(old_path)
     fs_helpers.move(old_path, new_path)
 
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_path)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, new_path)
     fs_helpers.move(new_path, old_path)
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, old_path)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, old_path)
 
 
 # move file into an indexed-but-moved directory
@@ -380,7 +387,7 @@ def test_get_path_oob_move_nested(fid_manager, old_path, new_path, stub_stat_crt
     fs_helpers.move(old_path, new_path)
     fs_helpers.move(old_test_path, new_test_path)
 
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_test_path)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, new_test_path)
 
 
 # move file into directory within an indexed-but-moved directory
@@ -399,7 +406,7 @@ def test_get_path_oob_move_deeply_nested(
     fs_helpers.move(old_path, new_path)
     fs_helpers.move(old_test_path, new_test_path)
 
-    assert fid_manager.get_path(id) == normalize_case(fid_manager, new_test_path)
+    assert fid_manager.get_path(id) == normalize_path(fid_manager, new_test_path)
 
 
 def test_move_unindexed(any_fid_manager, old_path, new_path, fs_helpers):
@@ -409,7 +416,7 @@ def test_move_unindexed(any_fid_manager, old_path, new_path, fs_helpers):
     assert id is not None
     assert any_fid_manager.get_id(old_path) is None
     assert any_fid_manager.get_id(new_path) == id
-    assert any_fid_manager.get_path(id) == normalize_case(any_fid_manager, new_path)
+    assert any_fid_manager.get_path(id) == normalize_path(any_fid_manager, new_path)
 
 
 def test_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):
@@ -421,7 +428,7 @@ def test_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):
     assert old_id == new_id
     assert any_fid_manager.get_id(old_path) is None
     assert any_fid_manager.get_id(new_path) == new_id
-    assert any_fid_manager.get_path(old_id) == normalize_case(any_fid_manager, new_path)
+    assert any_fid_manager.get_path(old_id) == normalize_path(any_fid_manager, new_path)
 
 
 # test for disjoint move handling

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -70,7 +70,7 @@ def new_path_grandchild(new_path_child):
 
 def get_id_nosync(fid_manager, path):
     if not os.path.isabs(path):
-        path = os.path.normcase(posixpath.join(fid_manager.root_dir, path))
+        path = normalize_path(fid_manager, posixpath.join(fid_manager.root_dir, path))
 
     row = fid_manager.con.execute("SELECT id FROM Files WHERE path = ?", (path,)).fetchone()
     return row and row[0]


### PR DESCRIPTION
The pull request addresses the issues encountered during CI on Windows platforms. There still appears to be an issue with symlinks, but only with Python 3.7 (and Windows), so that test has been skipped in that scenario (especially since support for 3.7 is going away).  I suspect this has something to do with `os.path.realpath` - which may be problematic on Windows based on this [link](https://stackoverflow.com/questions/43333640/python-os-path-realpath-for-symlink-in-windows).

A majority, nearly all, of the changes were related to how paths are normalized prior to persistence.  The `AbritraryFileIdManager` has been made filesystem-agnostic with this PR.  All slashes are converted to forward slashes with consecutive slashes removed.  As a result, even the value of `root_dir` (i.e., `content_root`) is converted, although the drive letter information remains.  This means that those using the `ArbitraryFileIdManager` with `FileContentsManagers` must be on homogeneous file systems (namely Windows vs. Unix) due to differing formats in their `root_dir` traits.

Because path normalization (and denormalization) varies between implementations, those internal methods were also abstracted.  Additionally, the `_move_recursive()`,  `_copy_recursive()` and `_delete_recursive()` methods on the ABC were updated to take a "path manager" (e.g., `os.path` or `posixpath`) since path joins are problematic when attempting to be filesystem-agnostic.

This pull request also removes a redundant select statement when checking timestamps since both the `crtime` and `mtime` values can be captured when retrieving the `path` and `ino` (inode) columns in `LocalFileIdManager.get_path()`.

I apologize for a large number of commits, but not having a Windows machine to debug directly against leads one down a long and arduous path.

Resolves: #6