### PR TITLE
Update check-jsonschema usage to latest style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,12 +47,8 @@ repos:
         additional_dependencies:
           ["flake8-bugbear==22.6.22", "flake8-implicit-str-concat==0.2.0"]
 
-  - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.18.4
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.19.2
     hooks:
-      - id: check-jsonschema
-        name: "Check GitHub Workflows"
-        files: ^\.github/workflows/
-        types: [yaml]
-        args: ["--schemafile", "https://json.schemastore.org/github-workflow"]
+      - id: check-github-workflows
         stages: [manual]


### PR DESCRIPTION
- update repo URL to modernize
- replace custom check hook with the check-github-workflows hook (stage is left as manual)

----

I'm trying to improve the common/normative home of this hook by finding repos which appear active and informing maintainers of the newer home. There's no harm in using the old URL, but I don't know that GitHub will serve the redirect indefinitely (especially if I take some accidentally destructive action, e.g. forking the repo back to my account).

This also looks to be part of the same org which originated https://github.com/python-jsonschema/check-jsonschema/issues/183 , so that and the related `jupyter-server` changes may be relevant here.

Cheers!