### PR TITLE
Relax jupyter_events dependency requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_server>=1.15, <3", "jupyter_events~=0.5.0"]
+dependencies = [
+    "jupyter_server>=1.15, <3",
+    "jupyter_events"
+]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=1.15, <3",
-    "jupyter_events"
+    "jupyter_events>=0.5.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION


Opening this PR in response to an error I get when installing the [Elyra](https://github.com/elyra-ai/elyra) package and following error
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
jupyter-server-fileid 0.6.0 requires jupyter-events~=0.5.0, but you have jupyter-events 0.6.3 which is incompatible.
```