### PR TITLE
Fix behavior for OOB move followed by IB move

### DIFF
--- a/jupyter_server_fileid/manager.py
+++ b/jupyter_server_fileid/manager.py
@@ -808,11 +808,10 @@ class LocalFileIdManager(BaseFileIdManager):
         # reasons, but this is needed to handle an edge case:
         # https://github.com/jupyter-server/jupyter_server_fileid/issues/62
         id = self._sync_file(new_path, stat_info)
-        if id is not None:
-            return id
+        if id is None:
+            # if no existing record, create a new one
+            id = self._create(new_path, stat_info)
 
-        # if no existing record, create a new one
-        id = self._create(new_path, stat_info)
         self.con.commit()
         return id
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -470,6 +470,40 @@ def test_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):
     assert any_fid_manager.get_path(old_id) == new_path
 
 
+def test_oob_ib_move(fid_manager, test_path, fs_helpers):
+    """
+    Test an out-of-band move followed by an in-band move.
+    """
+    new_path_1 = "path1"
+    new_path_2 = "path2"
+    id = fid_manager.index(test_path)
+
+    # out-of-band
+    fs_helpers.move(test_path, new_path_1)
+    # in-band
+    fs_helpers.move(new_path_1, new_path_2)
+    fid_manager.move(new_path_1, new_path_2)
+
+    assert id == fid_manager.get_id(new_path_2)
+
+
+def test_ib_oob_move(fid_manager, test_path, fs_helpers):
+    """
+    Test an in-band move followed by an out-of-band move.
+    """
+    new_path_1 = "path1"
+    new_path_2 = "path2"
+    id = fid_manager.index(test_path)
+
+    # in-band
+    fs_helpers.move(test_path, new_path_1)
+    fid_manager.move(test_path, new_path_1)
+    # out-of-band
+    fs_helpers.move(new_path_1, new_path_2)
+
+    assert id == fid_manager.get_id(new_path_2)
+
+
 # test for disjoint move handling
 # disjoint move: any out-of-band move that does not preserve stat info
 def test_disjoint_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -504,18 +504,6 @@ def test_ib_oob_move(fid_manager, test_path, fs_helpers):
     assert id == fid_manager.get_id(new_path_2)
 
 
-# test for disjoint move handling
-# disjoint move: any out-of-band move that does not preserve stat info
-def test_disjoint_move_indexed(any_fid_manager, old_path, new_path, fs_helpers):
-    old_id = any_fid_manager.index(old_path)
-
-    fs_helpers.delete(old_path)
-    fs_helpers.touch(new_path, dir=True)
-    new_id = any_fid_manager.move(old_path, new_path)
-
-    assert old_id == new_id
-
-
 def test_move_recursive(
     any_fid_manager,
     old_path,


### PR DESCRIPTION
- Fixes #62 

The reason this bug exists is because LocalFIDM didn't consider mixing out-of-band and in-band filesystem operations. This meant that originally, we did not call `_sync_file()` in `move()`, because we assumed the file was not moved out-of-band after it was indexed. This optimization was done for performance reasons, as the `_sync_*` methods are a little expensive.

However, as @dleen describes in the original issue, this error state is too easy to reach, and should be properly handled by LocalFIDM.