### PR TITLE
Database becomes locked when an exception is raised

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,9 +1,8 @@
 import ntpath
 import os
 import posixpath
-import sys
 import sqlite3
-
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -621,7 +620,6 @@ def test_db_journal_mode(any_fid_manager_class, fid_db_path, jp_root_dir, db_jou
         assert actual_journal_mode[0].upper() == expected_journal_mode
 
 
-
 def test_multiple_fileIdManager_connections_after_exception(fid_db_path):
     original_file_path = "/path/to/file"
     copy_location = "/path/to/copy"
@@ -646,4 +644,3 @@ def test_multiple_fileIdManager_connections_after_exception(fid_db_path):
     # that the database is now stuck in a locked state.
     manager_2 = ArbitraryFileIdManager(db_path=fid_db_path)
     manager_2.copy(original_file_path, another_copy_location)
-


### PR DESCRIPTION
I ran into a situation where the file ID database becomes locked after multiple copy operations to the same destination, i.e. 
```
sqlite3.OperationalError: database is locked
```

The steps to reproduced in JupyterLab are a little unique to my setup, however, it's quite easy to trigger with a simple unit test example, shared in this PR. 

I create two instances of a fileID manager (thus two connections to the same DB), make multiple copies with manager 1, trigger an expected `sqlite3.IntegrityError: UNIQUE constraint failed: Files.path`, then try writing to a new location from the second manager. 

You may say, multiple copy operations to the same path shouldn't be allowed, and I'd agree; however, they shouldn't lock other connections from writing. I believe we're at risk of locking the database _anytime_ we have an `INSERT` or `UPDATE` query and should handle these instances with the proper `.close()` logic or context manager. 